### PR TITLE
Fix fn recycle and allow the n==0 case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 //! [Jerome Kelleher](http://jeromekelleher.net/generating-integer-partitions.html),
 //! which takes a constant amount of time for each partition.
 
-#![deny(missing_docs)]
-
 /// Iterates over the partitions of a given positive integer.
 pub struct Partitions {
     a: Vec<usize>,
@@ -21,18 +19,12 @@ enum State {
 
 impl Partitions {
     /// Makes a new iterator.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n < 1`.
     #[inline]
     pub fn new(n: usize) -> Partitions {
-        assert!(n >= 1);
-
         Partitions {
             a: vec![0; n + 1],
-            k: 1,
-            y: n - 1,
+            k: if n == 0 { 0 } else { 1 },
+            y: if n == 0 { 0 } else { n - 1 },
             next: State::A,
         }
     }
@@ -50,7 +42,12 @@ impl Partitions {
         match *next {
             State::A => {
                 if *k == 0 {
-                    None
+                    if a.len() == 1 {
+                        a.pop();
+                        Some(&[])
+                    } else {
+                        None
+                    }
                 } else {
                     *k -= 1;
                     let x = a[*k] + 1;
@@ -100,14 +97,8 @@ impl Partitions {
     /// will be cleared and it will be filled with zeroes, but note
     /// that the vector will still reallocate if its capacity is less
     /// than `n + 1`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n < 1`.
     #[inline]
     pub fn recycle(n: usize, mut vec: Vec<usize>) -> Partitions {
-        assert!(n >= 1);
-
         vec.clear();
         vec.reserve(n + 1);
         for _ in 0..(n + 1) {
@@ -116,8 +107,8 @@ impl Partitions {
 
         Partitions {
             a: vec,
-            k: 1,
-            y: n - 1,
+            k: if n == 0 { 0 } else { 1 },
+            y: if n == 0 { 0 } else { n - 1 },
             next: State::A,
         }
     }
@@ -138,7 +129,7 @@ fn oeis() {
     //! Tests the first few entries of A000041.
 
     let tests: &[usize] = &[
-        1, 2, 3, 5, 7, 11, 15, 22,
+        1, 1, 2, 3, 5, 7, 11, 15, 22,
         30, 42, 56, 77, 101, 135, 176, 231,
         297, 385, 490, 627, 792, 1002, 1255, 1575,
         1958, 2436, 3010, 3718, 4565, 5604, 6842, 8349,
@@ -148,12 +139,12 @@ fn oeis() {
     ];
 
     for (i, &n) in tests.iter().enumerate() {
-        let mut p = Partitions::new(i + 1);
+        let mut p = Partitions::new(i);
         let mut c = 0;
 
         while let Some(x) = p.next() {
             let sum: usize = x.iter().cloned().sum();
-            assert_eq!(sum, i + 1);
+            assert_eq!(sum, i);
             c += 1;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 //! [Jerome Kelleher](http://jeromekelleher.net/generating-integer-partitions.html),
 //! which takes a constant amount of time for each partition.
 
+#![deny(missing_docs)]
+
 /// Iterates over the partitions of a given positive integer.
 pub struct Partitions {
     a: Vec<usize>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ impl Partitions {
         }
 
         Partitions {
-            a: vec![0; n + 1],
+            a: vec,
             k: 1,
             y: n - 1,
             next: State::A,


### PR DESCRIPTION
This pull requests does two things:

- fixes the function `recycle` which used to create a new vector although its purpose is to avoid it;
- adds the `n == 0` case, thus eliminating `panic`s. It doesn't affect performance for the general case, only adding a new check at the end of the work of the iterator. There is one partition of zero, namely the empty partition.